### PR TITLE
Add check for generating code parsed from "{**kwargs}"

### DIFF
--- a/mutpy/test/test_codegen.py
+++ b/mutpy/test/test_codegen.py
@@ -160,3 +160,7 @@ class CodegenTest(unittest.TestCase):
 
     def test_assert_without_message(self):
         self.assert_code_equal("assert True")
+
+    @unittest.skipIf(sys.version_info < (3, 5), 'checked statement not available for Python version')
+    def test_kwargs_in_dict(self):
+        self.assert_code_equal("{**kwargs}")


### PR DESCRIPTION
In Python you can unpack dicts into other dicts like this:

```python
new_dict = {**kwargs}
```
This caused codegen to fail before PR #3. So I added a check for it.