### PR TITLE
Refactor unittest constructs with self.fail(...) to improve readability and coverage

### DIFF
--- a/mutpy/test/test_operators.py
+++ b/mutpy/test/test_operators.py
@@ -77,10 +77,10 @@ class OperatorTestCase(unittest.TestCase):
 
     def assert_location(self, mutant):
         for node in ast.walk(mutant):
-            if 'lineno' in node._attributes and not hasattr(node, 'lineno'):
-                self.fail('Missing lineno in ' + str(node))
-            if 'col_offset' in node._attributes and not hasattr(node, 'col_offset'):
-                self.fail('Missing col_offset in ' + str(node))
+            if 'lineno' in node._attributes:
+                self.assertTrue(hasattr(node, 'lineno'), 'Missing lineno in ' + str(node))
+            if 'col_offset' in node._attributes:
+                self.assertTrue(hasattr(node, 'col_offset'), 'Missing col_offset in ' + str(node))
 
     def assert_mutation_lineo(self, lineno, lines):
         mutation_line = lines.pop(0)


### PR DESCRIPTION
Constructs with self.fail() decrease test coverage because these lines are only run, when the test finds a defect. Instead we should work witch assertions.