### PR TITLE
Improve codegen coverage

### DIFF
--- a/mutpy/codegen.py
+++ b/mutpy/codegen.py
@@ -180,7 +180,7 @@ class AbstractSourceGenerator(ast.NodeVisitor):
         self.newline(node)
         for idx, target in enumerate(node.targets):
             if idx:
-                self.write(', ')
+                self.write(' = ')
             self.visit(target)
         self.write(' = ')
         self.visit(node.value)
@@ -235,21 +235,6 @@ class AbstractSourceGenerator(ast.NodeVisitor):
         for base in node.bases:
             paren_or_comma()
             self.visit(base)
-        # XXX: the if here is used to keep this module compatible
-        #      with python 2.6.
-        if hasattr(node, 'keywords'):
-            for keyword in node.keywords:
-                paren_or_comma()
-                self.write(keyword.arg + '=')
-                self.visit(keyword.value)
-            if self._is_node_args_valid(node, 'starargs'):
-                paren_or_comma()
-                self.write('*')
-                self.visit(node.starargs)
-            if self._is_node_args_valid(node, 'kwargs'):
-                paren_or_comma()
-                self.write('**')
-                self.visit(node.kwargs)
         self.write(have_args and '):' or ':')
         self.body(node.body)
 
@@ -294,23 +279,6 @@ class AbstractSourceGenerator(ast.NodeVisitor):
         self.newline(node)
         self.write('pass', node)
 
-    def visit_Print(self, node):
-        # XXX: python 2.6 only
-        self.newline(node)
-        self.write('print ')
-        want_comma = False
-        if node.dest is not None:
-            self.write(' >> ')
-            self.visit(node.dest)
-            want_comma = True
-        for value in node.values:
-            if want_comma:
-                self.write(', ')
-            self.visit(value)
-            want_comma = True
-        if not node.nl:
-            self.write(',')
-
     def visit_Delete(self, node):
         self.newline(node)
         self.write('del ')
@@ -344,8 +312,6 @@ class AbstractSourceGenerator(ast.NodeVisitor):
         self.write('continue')
 
     def visit_Raise(self, node):
-        # XXX: Python 2.6 / 3.0 compatibility
-        self.newline(node)
         self.write('raise')
         if hasattr(node, 'exc') and node.exc is not None:
             self.write(' ')
@@ -493,9 +459,9 @@ class AbstractSourceGenerator(ast.NodeVisitor):
                 self.visit(node.step)
 
     def visit_ExtSlice(self, node):
-        for idx, item in node.dims:
+        for idx, item in enumerate(node.dims):
             if idx:
-                self.write(', ')
+                self.write(',')
             self.visit(item)
 
     def visit_Yield(self, node):
@@ -546,12 +512,6 @@ class AbstractSourceGenerator(ast.NodeVisitor):
     def visit_Starred(self, node):
         self.write('*')
         self.visit(node.value)
-
-    def visit_Repr(self, node):
-        # XXX: python 2.6 only
-        self.write('`')
-        self.visit(node.value)
-        self.write('`')
 
     # Helper Nodes
 

--- a/mutpy/codegen.py
+++ b/mutpy/codegen.py
@@ -593,36 +593,6 @@ class AbstractSourceGenerator(ast.NodeVisitor):
             self.visit(node.msg)
 
 
-class SourceGeneratorPython32(AbstractSourceGenerator):
-
-    __python_version__ = (3, 2)
-
-    def visit_TryExcept(self, node):
-        self.newline(node)
-        self.write('try:')
-        self.body(node.body)
-        for handler in node.handlers:
-            self.visit(handler)
-
-    def visit_TryFinally(self, node):
-        self.newline(node)
-        self.write('try:')
-        self.body(node.body)
-        self.newline(node)
-        self.write('finally:')
-        self.body(node.finalbody)
-
-    def visit_With(self, node):
-        self.newline(node)
-        self.write('with ')
-        self.visit(node.context_expr)
-        if node.optional_vars is not None:
-            self.write(' as ')
-            self.visit(node.optional_vars)
-        self.write(':')
-        self.body(node.body)
-
-
 class SourceGeneratorPython33(AbstractSourceGenerator):
 
     __python_version__ = (3, 3)
@@ -696,7 +666,6 @@ class SourceGeneratorPython35(SourceGeneratorPython34):
 
 
 SourceGenerator = utils.get_by_python_version([
-    SourceGeneratorPython32,
     SourceGeneratorPython33,
     SourceGeneratorPython34,
     SourceGeneratorPython35

--- a/mutpy/test/test_codegen.py
+++ b/mutpy/test/test_codegen.py
@@ -1,7 +1,7 @@
-import unittest
 import sys
-from mutpy import codegen, utils
+import unittest
 
+from mutpy import codegen, utils
 
 EOL = '\n'
 SIMPLE_ASSIGN = 'x = 1'
@@ -58,6 +58,9 @@ class CodegenTest(unittest.TestCase):
 
     def test_import(self):
         self.assert_code_equal("import x")
+
+    def test_aliased_import(self):
+        self.assert_code_equal("import x as y")
 
     def test_import_package(self):
         self.assert_code_equal("import x.y.z")
@@ -139,8 +142,14 @@ class CodegenTest(unittest.TestCase):
     def test_empty_return(self):
         self.assert_code_equal("def f():" + EOL + INDENT + 'return')
 
+    def test_return_value(self):
+        self.assert_code_equal("def f():" + EOL + INDENT + 'return 5')
+
     def test_empty_yield(self):
         self.assert_code_equal("def f():" + EOL + INDENT + 'yield')
+
+    def test_yield_value(self):
+        self.assert_code_equal("def f():" + EOL + INDENT + 'yield 5')
 
     def test_with(self):
         self.assert_code_equal("with x:" + EOL + INDENT + 'pass')
@@ -164,3 +173,48 @@ class CodegenTest(unittest.TestCase):
     @unittest.skipIf(sys.version_info < (3, 5), 'checked statement not available for Python version')
     def test_kwargs_in_dict(self):
         self.assert_code_equal("{**kwargs}")
+
+    def test_starred(self):
+        self.assert_code_equal("*args")
+
+    def test_list_comprehension(self):
+        self.assert_code_equal("x = [y.value for y in z if y.value >= 3]")
+
+    def test_dict_comprehension(self):
+        self.assert_code_equal("x = {y: z for (y, z) in a}")
+
+    def test_if_expression(self):
+        self.assert_code_equal("a if b else c")
+
+    def test_lambda(self):
+        self.assert_code_equal("lambda x: x ** 2 + 2 * x - 5")
+
+    def test_slice(self):
+        self.assert_code_equal("a[:2,:2]")
+
+    def test_dict(self):
+        self.assert_code_equal("{a: 3, b: 'c'}")
+
+    def test_global(self):
+        self.assert_code_equal("global x")
+
+    def test_nonlocal(self):
+        self.assert_code_equal("nonlocal x")
+
+    def test_multi_assign(self):
+        self.assert_code_equal("a = b = c")
+
+    def test_multi_assign_with_tuple(self):
+        self.assert_code_equal("(a, b) = enumerate(c)")
+
+    def test_for_else(self):
+        self.assert_code_equal("for a in b:" + EOL + INDENT + PASS + EOL + "else:" + EOL + INDENT + PASS)
+
+    def test_raise_exception(self):
+        self.assert_code_equal("raise Exception()")
+
+    def test_raise_exception_from(self):
+        self.assert_code_equal("raise Exception() from exc")
+
+    def test_class_with_multi_inheritance(self):
+        self.assert_code_equal("class A(B, C):" + EOL + INDENT + PASS)


### PR DESCRIPTION
Add codegen tests, remove Python 2.x and 3.0 compatibility from codegen and fix "a = b = c" to "a, b = c" conversion.