### PR TITLE
Reduce code duplication in test_coverage by adding custom assertions

### DIFF
--- a/mutpy/test/test_coverage.py
+++ b/mutpy/test/test_coverage.py
@@ -1,9 +1,9 @@
 import unittest
+
 from mutpy import coverage, utils
 
 
 class MarkerNodeTransformerTest(unittest.TestCase):
-
     def test_visit(self):
         node = utils.create_ast('x = y\ny = x')
         coverage.MarkerNodeTransformer().visit(node)
@@ -15,9 +15,16 @@ class MarkerNodeTransformerTest(unittest.TestCase):
 
 
 class CoverageInjectorTest(unittest.TestCase):
-
     def setUp(self):
         self.coverage_injector = coverage.CoverageInjector()
+
+    def assert_covered(self, nodes):
+        for node in nodes:
+            self.assertTrue(self.coverage_injector.is_covered(node))
+
+    def assert_not_covered(self, nodes):
+        for node in nodes:
+            self.assertFalse(self.coverage_injector.is_covered(node))
 
     def test_covered_node(self):
         node = utils.create_ast('x = 1\nif False:\n\ty = 2')
@@ -26,8 +33,7 @@ class CoverageInjectorTest(unittest.TestCase):
 
         assign_node = node.body[0]
         constant_node = node.body[0].targets[0]
-        self.assertTrue(self.coverage_injector.is_covered(assign_node))
-        self.assertTrue(self.coverage_injector.is_covered(constant_node))
+        self.assert_covered([assign_node, constant_node])
 
     def test_not_covered_node(self):
         node = utils.create_ast('if False:\n\ty = 2')
@@ -36,8 +42,7 @@ class CoverageInjectorTest(unittest.TestCase):
 
         assign_node = node.body[0].body[0]
         constant_node = node.body[0].body[0].targets[0]
-        self.assertFalse(self.coverage_injector.is_covered(assign_node))
-        self.assertFalse(self.coverage_injector.is_covered(constant_node))
+        self.assert_not_covered([assign_node, constant_node])
 
     def test_result(self):
         node = utils.create_ast('x = 1')
@@ -52,7 +57,7 @@ class CoverageInjectorTest(unittest.TestCase):
         self.coverage_injector.inject(node)
 
         import_node = node.body[0]
-        self.assertFalse(self.coverage_injector.is_covered(import_node))
+        self.assert_not_covered([import_node])
 
     def test_docstring_coverage(self):
         node = utils.create_ast('"""doc"""')
@@ -60,7 +65,7 @@ class CoverageInjectorTest(unittest.TestCase):
         self.coverage_injector.inject(node)
 
         docstring_node = node.body[0]
-        self.assertTrue(self.coverage_injector.is_covered(docstring_node))
+        self.assert_covered([docstring_node])
 
     def test_if_coverage(self):
         node = utils.create_ast(utils.f("""
@@ -81,11 +86,9 @@ class CoverageInjectorTest(unittest.TestCase):
         second_if_test_node = second_if_node.test
         second_if_body_el = second_if_node.body[0]
         else_body_el = second_if_node.orelse[0]
-        self.assertTrue(self.coverage_injector.is_covered(first_if_test_node))
-        self.assertFalse(self.coverage_injector.is_covered(first_if_body_el))
-        self.assertTrue(self.coverage_injector.is_covered(second_if_test_node))
-        self.assertTrue(self.coverage_injector.is_covered(second_if_body_el))
-        self.assertFalse(self.coverage_injector.is_covered(else_body_el))
+
+        self.assert_covered([first_if_test_node, second_if_test_node, second_if_body_el])
+        self.assert_not_covered([first_if_body_el, else_body_el])
 
     def test_while__coverage(self):
         node = utils.create_ast(utils.f("""
@@ -101,9 +104,9 @@ class CoverageInjectorTest(unittest.TestCase):
         while_test_node = while_node.test
         while_body_el = while_node.body[0]
         while_else_body_el = while_node.orelse[0]
-        self.assertTrue(self.coverage_injector.is_covered(while_test_node))
-        self.assertFalse(self.coverage_injector.is_covered(while_body_el))
-        self.assertTrue(self.coverage_injector.is_covered(while_else_body_el))
+
+        self.assert_covered([while_test_node, while_else_body_el])
+        self.assert_not_covered([while_body_el])
 
     def test_func_def_coverage(self):
         node = utils.create_ast(utils.f("""
@@ -116,9 +119,9 @@ class CoverageInjectorTest(unittest.TestCase):
         func_node = node.body[0]
         func_body_el = func_node.body[0]
         arg_node = func_node.args.args[0]
-        self.assertTrue(self.coverage_injector.is_covered(func_node))
-        self.assertTrue(self.coverage_injector.is_covered(arg_node))
-        self.assertFalse(self.coverage_injector.is_covered(func_body_el))
+
+        self.assert_covered([func_node, arg_node])
+        self.assert_not_covered([func_body_el])
 
     def test_class_def_coverage(self):
         node = utils.create_ast(utils.f("""
@@ -133,9 +136,8 @@ class CoverageInjectorTest(unittest.TestCase):
         class_node = node.body[0]
         base_node = class_node.bases[0]
         func_body_el = class_node.body[0].body[0]
-        self.assertTrue(self.coverage_injector.is_covered(class_node))
-        self.assertTrue(self.coverage_injector.is_covered(base_node))
-        self.assertFalse(self.coverage_injector.is_covered(func_body_el))
+        self.assert_covered([class_node, base_node])
+        self.assert_not_covered([func_body_el])
 
     def test_try_coverage(self):
         node = utils.create_ast(utils.f("""
@@ -151,10 +153,8 @@ class CoverageInjectorTest(unittest.TestCase):
         try_body_el = try_node.body[0]
         except_node = try_node.handlers[0]
         except_body_el = except_node.body[0]
-        self.assertTrue(self.coverage_injector.is_covered(try_node))
-        self.assertTrue(self.coverage_injector.is_covered(try_body_el))
-        self.assertFalse(self.coverage_injector.is_covered(except_node))
-        self.assertFalse(self.coverage_injector.is_covered(except_body_el))
+        self.assert_covered([try_node, try_body_el])
+        self.assert_not_covered([except_node, except_body_el])
 
     def test_except_coverage(self):
         node = utils.create_ast(utils.f("""
@@ -170,10 +170,7 @@ class CoverageInjectorTest(unittest.TestCase):
         try_body_el = try_node.body[0]
         except_node = try_node.handlers[0]
         except_body_el = except_node.body[0]
-        self.assertTrue(self.coverage_injector.is_covered(try_node))
-        self.assertTrue(self.coverage_injector.is_covered(try_body_el))
-        self.assertTrue(self.coverage_injector.is_covered(except_node))
-        self.assertTrue(self.coverage_injector.is_covered(except_body_el))
+        self.assert_covered([try_node, try_body_el, except_node, except_body_el])
 
     def test_for_coverage(self):
         node = utils.create_ast(utils.f("""
@@ -188,26 +185,19 @@ class CoverageInjectorTest(unittest.TestCase):
         for_node = node.body[0]
         for_body_el = for_node.body[0]
         else_body_el = for_node.orelse[0]
-        self.assertTrue(self.coverage_injector.is_covered(for_node))
-        self.assertTrue(self.coverage_injector.is_covered(for_node.target))
-        self.assertTrue(self.coverage_injector.is_covered(for_node.iter))
-        self.assertFalse(self.coverage_injector.is_covered(for_body_el))
-        self.assertTrue(self.coverage_injector.is_covered(else_body_el))
+        self.assert_covered([for_node, for_node.target, for_node.iter, else_body_el])
+        self.assert_not_covered([for_body_el])
 
 
 class CoverageTestResultTest(unittest.TestCase):
-
     def test_run(self):
-
         coverage_injector = coverage.CoverageInjector()
 
         class A:
-
             def x(self):
                 coverage_injector.covered_nodes.add(1)
 
         class ATest(unittest.TestCase):
-
             def test_x(self):
                 A().x()
 


### PR DESCRIPTION
This time I reduce code duplication in tests just by introducing two custom assertions. Is this still impacting the readability too much?