### PR TITLE
Add section about test runners to README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -234,6 +234,13 @@ Experimental mutation operators:
 -  SVD - self variable deletion
 -  ZIL - zero iteration loop
 
+Supported Test Runners
+----------------------
+
+Currently the following test runners are supported by MutPy:
+
+- `unittest <https://docs.python.org/3/library/unittest.html>`_
+
 License
 -------
 


### PR DESCRIPTION
The current README does not tell the user outright, what test runners are possible (see #17 ). We should provide a list, which will hopefully exapnd in the future.