### PR TITLE
Add templates to package_data in setup.py (fixes #25)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ python:
   - 3.5
   - 3.6
 install:
+  # python 3.3 compatibility
+  - if [[ $TRAVIS_PYTHON_VERSION == 3.3 ]]; then pip install virtualenv==15.1.0 setuptools==39.2.0; fi
   - pip install tox-travis
   - pip install coveralls
 script:

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
     url='https://github.com/mutpy/mutpy',
     download_url='https://github.com/mutpy/mutpy',
     packages=['mutpy'],
+    package_data={'mutpy': ['templates/*.html']},
     scripts=['bin/mut.py'],
     install_requires=requirements,
     test_suite='mutpy.test',


### PR DESCRIPTION
It seems that including files MANIFEST.in is not enough. After adding the template files also to package_data inside setup.py the template files actually are installed into site-packages.