### PR TITLE
Add mutpy.operators to packages in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     author_email='halas.konrad@gmail.com',
     url='https://github.com/mutpy/mutpy',
     download_url='https://github.com/mutpy/mutpy',
-    packages=['mutpy'],
+    packages=['mutpy', 'mutpy.operators'],
     scripts=['bin/mut.py'],
     install_requires=requirements,
     test_suite='mutpy.test',


### PR DESCRIPTION
When I split up operators.py into multiple files I forgot add "mutpy.operators" to packages in setup.py. This leads to MutPy being distributed without any operators crashing the program.