### PR TITLE
Fix line numbers of mutants and remove obsolete parentheses in tests

### DIFF
--- a/mutpy/operators/base.py
+++ b/mutpy/operators/base.py
@@ -119,6 +119,8 @@ class MutationOperator:
         if not hasattr(new_node, 'parent'):
             new_node.children = old_node.children
             new_node.parent = old_node.parent
+        if not hasattr(new_node, 'lineno') and hasattr(old_node, 'lineno'):
+            new_node.lineno = old_node.lineno
         if hasattr(old_node, 'marker'):
             new_node.marker = old_node.marker
 
@@ -129,6 +131,15 @@ class MutationOperator:
     def getattrs_like(ob, attr_like):
         pattern = re.compile(attr_like + "($|(_\w+)+$)")
         return [getattr(ob, attr) for attr in dir(ob) if pattern.match(attr)]
+
+    def set_lineno(self, node, lineno):
+        for n in ast.walk(node):
+            if hasattr(n, 'lineno'):
+                n.lineno = lineno
+
+    def shift_lines(self, nodes, shift_by=1):
+        for node in nodes:
+            ast.increment_lineno(node, shift_by)
 
     @classmethod
     def name(cls):

--- a/mutpy/operators/decorator.py
+++ b/mutpy/operators/decorator.py
@@ -31,8 +31,12 @@ class AbstractMethodDecoratorInsertionMutationOperator(MutationOperator):
                 decorator_name = decorator.id
             if decorator_name == self.get_decorator_name():
                 raise MutationResign()
-
-        decorator = ast.Name(id=self.get_decorator_name(), ctx=ast.Load())
+        if node.decorator_list:
+            lineno = node.decorator_list[-1].lineno
+        else:
+            lineno = node.lineno
+        decorator = ast.Name(id=self.get_decorator_name(), ctx=ast.Load(), lineno=lineno)
+        self.shift_lines(node.body, 1)
         node.decorator_list.append(decorator)
         return node
 

--- a/mutpy/operators/loop.py
+++ b/mutpy/operators/loop.py
@@ -5,7 +5,7 @@ from mutpy.operators import copy_node, MutationOperator
 
 class OneIterationLoop(MutationOperator):
     def one_iteration(self, node):
-        node.body.append(ast.Break())
+        node.body.append(ast.Break(lineno=node.body[-1].lineno + 1))
         return node
 
     @copy_node
@@ -33,7 +33,7 @@ class ReverseIterationLoop(MutationOperator):
 
 class ZeroIterationLoop(MutationOperator):
     def zero_iteration(self, node):
-        node.body = [ast.Break()]
+        node.body = [ast.Break(lineno=node.body[0].lineno)]
         return node
 
     @copy_node

--- a/mutpy/test/test_controller.py
+++ b/mutpy/test/test_controller.py
@@ -320,10 +320,10 @@ class HighOrderMutatorTest(unittest.TestCase):
                 self.assertEqual('a', codegen.to_source(mutant))
                 self.assertEqual(len(mutations), 1)
             elif number == 1:
-                self.assertEqual('(+a)', codegen.to_source(mutant))
+                self.assertEqual('+a', codegen.to_source(mutant))
                 self.assertEqual(len(mutations), 1)
         self.assertEqual(number, 1)
-        self.assertEqual(codegen.to_source(target_ast), '(-a)')
+        self.assertEqual(codegen.to_source(target_ast), '-a')
 
     def test_second_order_mutation_with_multiple_visitors(self):
         mutator = controller.HighOrderMutator(


### PR DESCRIPTION
The latest version of astmonkey heavily relies on correct line numbers (lineno attribute of a node object).
Many operators do not correctly set the linenumbers.
This PR is attempting to fix that.