### PR TITLE
-m flag now prints mutation diff instead of just the mutation

### DIFF
--- a/mutpy/controller.py
+++ b/mutpy/controller.py
@@ -128,7 +128,7 @@ class MutationController(views.ViewNotifier):
             if self.mutation_number and self.mutation_number != mutation_number:
                 self.score.inc_incompetent()
                 continue
-            self.notify_mutation(mutation_number, mutations, target_module.__name__, mutant_ast)
+            self.notify_mutation(mutation_number, mutations, target_module, mutant_ast)
             mutant_module = self.create_mutant_module(target_module, mutant_ast)
             if mutant_module:
                 self.run_tests_with_mutant(total_duration, mutant_module, mutations, coverage_result)

--- a/mutpy/test/test_views.py
+++ b/mutpy/test/test_views.py
@@ -1,8 +1,23 @@
+import sys
 import unittest
+from contextlib import contextmanager
+from io import StringIO
 
-from mutpy.views import QuietTextView
+from mutpy import utils
+from mutpy.views import QuietTextView, TextView
 
 COLOR_RED = 'red'
+
+
+@contextmanager
+def captured_output():
+    new_out, new_err = StringIO(), StringIO()
+    old_out, old_err = sys.stdout, sys.stderr
+    try:
+        sys.stdout, sys.stderr = new_out, new_err
+        yield sys.stdout, sys.stderr
+    finally:
+        sys.stdout, sys.stderr = old_out, old_err
 
 
 class QuietTextViewTest(unittest.TestCase):
@@ -19,3 +34,27 @@ class QuietTextViewTest(unittest.TestCase):
         colored_text = text_view.decorate(text, color=COLOR_RED)
         # then
         self.assertEqual(expected_colored_text, colored_text)
+
+
+class TextViewTest(unittest.TestCase):
+    SEPARATOR = '--------------------------------------------------------------------------------'
+    EOL = "\n"
+
+    @staticmethod
+    def get_text_view(colored_output=False, show_mutants=False):
+        return TextView(colored_output=colored_output, show_mutants=show_mutants)
+
+    def test_print_code(self):
+        # given
+        text_view = self.get_text_view(show_mutants=True)
+        original = utils.create_ast('x = x + 1')
+        mutant = utils.create_ast('x = x - 1')
+        # when
+        with captured_output() as (out, err):
+            text_view.print_code(mutant, original)
+        # then
+        output = out.getvalue().strip()
+        self.assertEqual(
+            self.SEPARATOR + self.EOL + '- 1: x = x + 1' + self.EOL + '+ 1: x = x - 1' + self.EOL + self.SEPARATOR,
+            output
+        )


### PR DESCRIPTION
For a problem description see #38,#40.

I removed the line number in the heading, because sometimes (e.g. when inserting a super call) this line number can be misleading (see #38).

The mutant output is now in a diff-like format. When colored, the "+" lines are colored green and the "-" lines are colored blue. I did not use the color red to avoid the impression that a mutant survived or something else is wrong.

@konradhalas Any thoughts on this?

Example:

Old
```
   - [#  48] SIR example.simple:40 : 
--------------------------------------------------------------------------------
 36:         
 37:         return i
 38:     
 39:     def last_two(self, x):
~40:         return x[:]
 41:     
 42:     def empty_string(self):
 43:         return ''
 44:     
 45:     @notmutate
```

New
```
   - [#  48] SIR example.simple: 
--------------------------------------------------------------------------------
  36:         
  37:         return i
  38:     
  39:     def last_two(self, x):
- 40:         return x[-2:]
+ 40:         return x[:]
  41:     
  42:     def empty_string(self):
  43:         return ''
  44:     
--------------------------------------------------------------------------------
```