### PR TITLE
Load CSS and JS from cdnjs instead of http://alexgorbatchev.com

### DIFF
--- a/mutpy/templates/detail.html
+++ b/mutpy/templates/detail.html
@@ -3,13 +3,13 @@
 {% block title %}MutPy mutation report - mutation #{{ number }}{% endblock %}
 
 {% block css %}
-<link href="http://alexgorbatchev.com/pub/sh/current/styles/shCore.css" rel="stylesheet" type="text/css" />
-<link href="http://alexgorbatchev.com/pub/sh/current/styles/shThemeDefault.css" rel="stylesheet" type="text/css" />
+<link href="https://cdnjs.cloudflare.com/ajax/libs/SyntaxHighlighter/3.0.83/styles/shCore.min.css" rel="stylesheet" type="text/css" />
+<link href="https://cdnjs.cloudflare.com/ajax/libs/SyntaxHighlighter/3.0.83/styles/shThemeDefault.min.css" rel="stylesheet" type="text/css" />
 {% endblock %}
 
 {% block js %}
-<script src="http://alexgorbatchev.com/pub/sh/current/scripts/shCore.js" type="text/javascript"></script>
-<script src="http://alexgorbatchev.com/pub/sh/current/scripts/shBrushPython.js" type="text/javascript"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/SyntaxHighlighter/3.0.83/scripts/shCore.min.js" type="text/javascript"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/SyntaxHighlighter/3.0.83/scripts/shBrushPython.min.js" type="text/javascript"></script>
 <script type="text/javascript">
     SyntaxHighlighter.all();
     window.setTimeout(function () {


### PR DESCRIPTION
Loading SyntaxHighlighter content from `http://alexgorbatchev.com/pub/sh/current/**` is not working anymore, which was resulting in broken html outputs (when trying to access mutation details it would stuck on loading).

This pull request points SyntaxHighlighter dependency to `cdnjs`.

https://cdnjs.com/libraries/SyntaxHighlighter