### PR TITLE
Fix error in python 3 calling isAlive method

### DIFF
--- a/mutpy/utils.py
+++ b/mutpy/utils.py
@@ -354,7 +354,7 @@ class MutationTestRunnerThread(MutationTestRunner, Thread):
         self.result = None
 
     def terminate(self):
-        if self.isAlive():
+        if self.is_alive():
             res = ctypes.pythonapi.PyThreadState_SetAsyncExc(ctypes.c_long(self.ident), ctypes.py_object(SystemExit))
             if res == 0:
                 raise ValueError('Invalid thread id.')


### PR DESCRIPTION
Python 2.6 added is_alive spelling for the method: https://docs.python.org/2.7/library/threading.html#threading.Thread.is_alive
Python 3.9 documentation only have is_alive, without isAlive spelling: https://docs.python.org/3.9/library/threading.html#threading.Thread.is_alive