### PR TITLE
Fixed Python 3.8 not generating 'CRP' mutations (fixes #55)

### DIFF
--- a/mutpy/operators/misc.py
+++ b/mutpy/operators/misc.py
@@ -26,6 +26,30 @@ class ConstantReplacement(MutationOperator):
     FIRST_CONST_STRING = 'mutpy'
     SECOND_CONST_STRING = 'python'
 
+    def mutate_Constant_num(self, node):
+        if isinstance(node.value, (int, float)) and not isinstance(node.value, bool):
+            return ast.Constant(n=node.n + 1)
+        else:
+            raise MutationResign()
+
+    def mutate_Constant_str(self, node):
+        if isinstance(node.value, str):
+            if utils.is_docstring(node):
+                raise MutationResign()
+
+            if node.s != self.FIRST_CONST_STRING:
+                return ast.Constant(s=self.FIRST_CONST_STRING)
+            else:
+                return ast.Constant(s=self.SECOND_CONST_STRING)
+        else:
+            raise MutationResign()
+
+    def mutate_Constant_str_empty(self, node):
+        if isinstance(node.value, str):
+            return ast.Constant(s='')
+        else:
+            raise MutationResign()
+
     def mutate_Num(self, node):
         return ast.Num(n=node.n + 1)
 

--- a/mutpy/operators/misc.py
+++ b/mutpy/operators/misc.py
@@ -26,6 +26,20 @@ class ConstantReplacement(MutationOperator):
     FIRST_CONST_STRING = 'mutpy'
     SECOND_CONST_STRING = 'python'
 
+    def help_str(self, node):
+        if utils.is_docstring(node):
+            raise MutationResign()
+
+        if node.s != self.FIRST_CONST_STRING:
+            return self.FIRST_CONST_STRING
+        else:
+            return self.SECOND_CONST_STRING
+
+    def help_str_empty(self, node):
+        if not node.s or utils.is_docstring(node):
+            raise MutationResign()
+        return ''
+
     def mutate_Constant_num(self, node):
         if isinstance(node.value, (int, float)) and not isinstance(node.value, bool):
             return ast.Constant(n=node.n + 1)
@@ -34,19 +48,13 @@ class ConstantReplacement(MutationOperator):
 
     def mutate_Constant_str(self, node):
         if isinstance(node.value, str):
-            if utils.is_docstring(node):
-                raise MutationResign()
-
-            if node.s != self.FIRST_CONST_STRING:
-                return ast.Constant(s=self.FIRST_CONST_STRING)
-            else:
-                return ast.Constant(s=self.SECOND_CONST_STRING)
+            return ast.Constant(s=self.help_str(node))
         else:
             raise MutationResign()
 
     def mutate_Constant_str_empty(self, node):
         if isinstance(node.value, str):
-            return ast.Constant(s='')
+            return ast.Constant(s=self.help_str_empty(node))
         else:
             raise MutationResign()
 
@@ -54,19 +62,10 @@ class ConstantReplacement(MutationOperator):
         return ast.Num(n=node.n + 1)
 
     def mutate_Str(self, node):
-        if utils.is_docstring(node):
-            raise MutationResign()
-
-        if node.s != self.FIRST_CONST_STRING:
-            return ast.Str(s=self.FIRST_CONST_STRING)
-        else:
-            return ast.Str(s=self.SECOND_CONST_STRING)
+        return ast.Str(s=self.help_str(node))
 
     def mutate_Str_empty(self, node):
-        if not node.s or utils.is_docstring(node):
-            raise MutationResign()
-
-        return ast.Str(s='')
+        return ast.Str(s=self.help_str_empty(node))
 
     @classmethod
     def name(cls):


### PR DESCRIPTION
Since Python 3.8 `Num`, `Str`, `Bytes`, `Ellipsis` and `NameConstant` AST nodes are replaced and combined into the `Constant` node. (https://greentreesnakes.readthedocs.io/en/latest/nodes.html)
Hence there is the need to declare visitor methods producing the same mutations for `Constant` nodes. These visitors have to return `Constant` AST nodes in order to produce non deprecated Python 3.8 code. 