### PR TITLE
Include license file in source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include requirements/*
 include mutpy/templates/*
+include LICENSE


### PR DESCRIPTION
It would be helpful to include the license file in the source distribution.