### PR TITLE
Changed trigger for MutPy

### DIFF
--- a/bin/mut.py
+++ b/bin/mut.py
@@ -1,7 +1,0 @@
-#! /usr/bin/env python3
-
-import sys
-from mutpy import commandline
-
-if __name__ == '__main__':
-    commandline.main(sys.argv)

--- a/mutpy/mut.py
+++ b/mutpy/mut.py
@@ -1,0 +1,6 @@
+#! /usr/bin/env python3
+
+def main():
+    import sys
+    from mutpy import commandline
+    commandline.main(sys.argv)

--- a/setup.py
+++ b/setup.py
@@ -28,10 +28,15 @@ setup(
     download_url='https://github.com/mutpy/mutpy',
     packages=['mutpy', 'mutpy.operators', 'mutpy.test_runners'],
     package_data={'mutpy': ['templates/*.html']},
-    scripts=['bin/mut.py'],
+    scripts=[],
     install_requires=requirements,
     extras_require={
         'pytest': ["pytest>=3.0"]
+    },
+    entry_points={
+        'console_scripts': [
+            'mutpy=mutpy.mut:main'
+        ]
     },
     test_suite='mutpy.test',
     classifiers=[


### PR DESCRIPTION
Now MutPy can be called by `mutpy` instead of `mut.py`. This is better because of more portability and also removes any scope for errors like those mentioned in #63 and #71.