### PR TITLE
Update utils.py - Changed isAlive() method call to is_alive()

### DIFF
--- a/mutpy/utils.py
+++ b/mutpy/utils.py
@@ -354,7 +354,7 @@ class MutationTestRunnerThread(MutationTestRunner, Thread):
         self.result = None
 
     def terminate(self):
-        if self.isAlive():
+        if self.is_alive():
             res = ctypes.pythonapi.PyThreadState_SetAsyncExc(ctypes.c_long(self.ident), ctypes.py_object(SystemExit))
             if res == 0:
                 raise ValueError('Invalid thread id.')


### PR DESCRIPTION
 The method isAlive() has been renamed to is_alive() in Python 3.9 and later versions. Because changes have been noted in Python’s Thread class method naming.